### PR TITLE
repaired app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -7,8 +7,6 @@ class TfApp(App):
     def fmt_layoutRich(app, n, **kwargs):
         api = app.api
         F = api.F
-        material = F.g_cons.v(n)
-        after = F.trailer.v(n) or ""
+        material = F.sign.v(n)
         
-        #return f"{material}"
-        return f"{material}{after}"
+        return f"{material}"


### PR DESCRIPTION
App did not function properly anymore, I think because I tried to fix it some weeks ago. Now it works again, space between B and R>CJT and similar cases has not been solved yet, is done in a later pull request.