### PR TITLE
update citation.cff

### DIFF
--- a/citation.cff
+++ b/citation.cff
@@ -16,4 +16,4 @@ version: 3.1
 doi: 10.5281/zenodo.7734632
 date-released: 2023-06-21
 url: "https://github.com/DT-UCPH/sp"
-license: "CC-BY-NC-4.0"
+license: CC-BY-NC-4.0


### PR DESCRIPTION
License ID is still not rekognized by zenodo. So here is a little update to hopefully fix the problem.