### PR TITLE
delete license id

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,8 +14,6 @@
         }
     ],
 
-    "license": "CC-BY-NC-4.0",
-
     "title": "The Samaritan Pentateuch",
 
 }


### PR DESCRIPTION
This update deletes the license id from .zenodo.json.